### PR TITLE
Fix empty $user object within onChannelPart

### DIFF
--- a/classes/outragebot/event/events/part.php
+++ b/classes/outragebot/event/events/part.php
@@ -27,8 +27,8 @@ class Part extends Event\Template
 	 */
 	public function invoke()
 	{
-		$channel = $this->instance->getChannel($this->packet->parts[2]);
-		$user = $this->instance->getUser($this->packet->hostmask);
+		$channel = $this->instance->getChannel($this->packet->payload);
+		$user = $this->instance->getUser($this->packet->user);
 		
 		$this->dispatch([ $channel, $user, $this->packet->payload ]);
 		


### PR DESCRIPTION
Found by CM707

`$user` is totally empty within the `onChannelPart` event due to it not being passed properly by the `PART` event file.

`PHP Catchable fatal error:  Method OUTRAGEbot\Element\User::__toString() must return a string value in blablabla on line 288`
