### PR TITLE
Fix IRC client hostnames not updating

### DIFF
--- a/classes/outragebot/connection/instance.php
+++ b/classes/outragebot/connection/instance.php
@@ -273,6 +273,8 @@ class Instance
 		
 		if(!isset($this->users[$hostmask->nickname]))
 			$this->users[$hostmask->nickname] = new Element\User($this, $hostmask);
+		else
+			$this->users[$hostmask->nickname]->hostmask = $hostmask;
 		
 		return $this->users[$hostmask->nickname];
 	}


### PR DESCRIPTION
Addresses an issue where under certain circumstances, valid hostnames would not be recognised as bot owners.
