### PR TITLE
Part message warning fix

### DIFF
--- a/classes/outragebot/event/events/part.php
+++ b/classes/outragebot/event/events/part.php
@@ -27,7 +27,7 @@ class Part extends Event\Template
 	 */
 	public function invoke()
 	{
-		$channel = $this->instance->getChannel($this->packet->payload);
+		$channel = $this->instance->getChannel($this->packet->parts[2]);
 		$user = $this->instance->getUser($this->packet->user);
 		
 		$this->dispatch([ $channel, $user, $this->packet->payload ]);


### PR DESCRIPTION
PHP warnings are generated when a user parts without using a part message:

`PHP Warning:  Attempt to modify property of non-object in classes/outragebot/event/events/part.php on line 36`

Spotted by `JackTheRipper` / `CM707`
