### PR TITLE
Fix scripts not unloading events properly

### DIFF
--- a/classes/outragebot/connection/instance.php
+++ b/classes/outragebot/connection/instance.php
@@ -349,6 +349,7 @@ class Instance
 		if(!isset($this->scripts[$script]))
 			return false;
 		
+		$this->scripts[$script]->destruct();
 		unset($this->scripts[$script]);
 		return true;
 	}

--- a/classes/outragebot/script/instance.php
+++ b/classes/outragebot/script/instance.php
@@ -67,11 +67,6 @@ class Instance
 	public final function __destruct()
 	{
 		$this->destruct();
-		$this->off();
-		
-		unset($this->context);
-		unset($this->instance);
-		
 		return true;
 	}
 	
@@ -90,6 +85,10 @@ class Instance
 	 */
 	public function destruct()
 	{
+		$this->off();
+		
+		unset($this->context);
+		unset($this->instance);
 		return true;
 	}
 	


### PR DESCRIPTION
Script events still execute even after calling `$this->instance->deactivateScript()`.

This calls the script template `destruct()` method to resolve the issue.
